### PR TITLE
cw20-migrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -328,6 +328,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw2"
+version = "1.0.1"
+source = "git+https://github.com/CosmWasm/cw-plus#9c1daf74ab9ad1981184648ee219dce3b370c26d"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw20"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +351,36 @@ dependencies = [
  "cw-utils 1.0.1",
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "cw20"
+version = "1.0.1"
+source = "git+https://github.com/CosmWasm/cw-plus#9c1daf74ab9ad1981184648ee219dce3b370c26d"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw20-base"
+version = "2.0.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test 0.16.2",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/CosmWasm/cw-plus)",
+ "cw20 1.0.1 (git+https://github.com/CosmWasm/cw-plus)",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+ "tokenfactory-types",
 ]
 
 [[package]]
@@ -580,8 +623,8 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "cw20",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom",
  "schemars",
  "serde",
@@ -953,7 +996,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "serde",
  "thiserror",

--- a/contracts/cw20-base/.cargo/config
+++ b/contracts/cw20-base/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --bin schema"

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "cw20-base"
+version = "2.0.0"
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+edition = "2021"
+description = "Basic implementation of a CosmWasm-20 compliant token"
+license = "Apache-2.0"
+repository = "https://github.com/CosmWasm/cw-plus"
+homepage = "https://cosmwasm.com"
+documentation = "https://docs.cosmwasm.com"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-schema = { version = "1.1.0" }
+cw-utils = "1.0.1"
+#cw2 = { path = "../../packages/cw2", version = "1.0.1" }
+#cw20 = { path = "../../packages/cw20", version = "1.0.1" }
+cw2 = { git = "https://github.com/CosmWasm/cw-plus", version = "1.0.1"}
+cw20 = { git = "https://github.com/CosmWasm/cw-plus", version = "1.0.1"}
+cw-storage-plus = "1.0.1"
+cosmwasm-std = { version = "1.1.0" }
+schemars = "0.8.1"
+semver = "1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.23" }
+
+tokenfactory-types = { path = "../../packages/tokenfactory-types" }
+
+[dev-dependencies]
+cw-multi-test = "0.16.1"

--- a/contracts/cw20-base/README.md
+++ b/contracts/cw20-base/README.md
@@ -1,0 +1,3 @@
+# CW20 Basic
+
+This is a token-factory migration implementation of a base cw20 contract, from https://github.com/CosmWasm/cw-plus.

--- a/contracts/cw20-base/src/bin/schema.rs
+++ b/contracts/cw20-base/src/bin/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+
+use cw20_base::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -1,0 +1,185 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::Order::Ascending;
+use cosmwasm_std::{
+    to_binary, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdError,
+    StdResult, SubMsg, Uint128, WasmMsg,
+};
+
+use cw2::set_contract_version;
+use cw20::{    
+    DownloadLogoResponse, EmbeddedLogo, Logo, MarketingInfoResponse, MinterResponse,
+    TokenInfoResponse,
+};
+use cw_utils::ensure_from_older_version;
+
+use crate::enumerable::{query_all_accounts};
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::state::{BALANCES, LOGO, MARKETING_INFO,
+    TOKEN_INFO, ALLOWANCES, ALLOWANCES_SPENDER, MIGRATION, MigrateConfig,
+};
+
+use tokenfactory_types::msg::ExecuteMsg::Mint;
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:cw20-base";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Err(ContractError::CannotInstantiate {})
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+#[allow(unused_variables)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::MigrateTokens { limit } => {            
+            // Maybe allow anyone to do this to migrate tokens permissionlessly / with bots. Save the lasrt key in the limit to state so we know where to start back?
+            // This way we do not have to burn tokens incase something goes very wrong.
+
+
+
+                // iterate all accounts, and mint 1:1 tokens
+            //     let data = BALANCES
+            //     .range(deps.storage, None, None, Ascending)
+            //     .collect::<StdResult<Vec<_>>>()?;   
+            // let mut coin = vec![Coin {
+            //     amount: Uint128::zero(),
+            //     denom: msg.tf_denom,
+            // }];
+
+            // let mint_msgs = data
+            //     .iter()
+            //     .map(|(addr, balance)| {
+            //         coin[0].amount = balance.clone();
+            //         let mint_msg = Mint {
+            //             address: addr.to_string(),
+            //             denom: coin.clone(),
+            //         };
+
+            //         let wasm_mint = WasmMsg::Execute {
+            //             contract_addr: tf_core.clone(),
+            //             msg: to_binary(&mint_msg).unwrap(),
+            //             funds: vec![],
+            //         };
+
+            //         SubMsg::new(wasm_mint)
+            //     })
+            //     .collect::<Vec<_>>();
+            // .add_submessages(mint_msgs) 
+
+            // for each account, burn their tokens and mint new ones through tf_core_addr
+            // if too many, maybe we have to set this contract as the admin and mint tokens directly through TokenMsg here?
+            // Then transfer back to user / contract who called the migrate message on this or something
+
+
+            // lower balance
+            // BALANCES.update(
+            //     deps.storage,
+            //     &info.sender,
+            //     |balance: Option<Uint128>| -> StdResult<_> {
+            //         Ok(balance.unwrap_or_default().checked_sub(amount)?)
+            //     },
+            // )?;
+            // reduce total_supply
+            // TOKEN_INFO.update(deps.storage, |mut info| -> StdResult<_> {
+            //     info.total_supply = info.total_supply.checked_sub(amount)?;
+            //     Ok(info)
+            // })?;
+            // let res = Response::new()
+            //     .add_attribute("action", "burn")
+            //     .add_attribute("from", info.sender)
+            //     .add_attribute("amount", amount);
+            // Ok(res)
+
+
+            Ok(Response::new())
+        },
+    }
+}
+
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+#[allow(unused_variables)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Minter {} => to_binary(&None as &Option<MinterResponse>),
+    
+        // Kept the same
+        QueryMsg::MarketingInfo {} => to_binary(&MARKETING_INFO.may_load(deps.storage)?.unwrap_or_default()),
+        QueryMsg::DownloadLogo {} => to_binary(&query_download_logo(deps)?),
+        QueryMsg::TokenInfo {} => to_binary(&query_token_info(deps)?),        
+        QueryMsg::AllAccounts { start_after, limit } => {
+            to_binary(&query_all_accounts(deps, start_after, limit)?)
+        }
+    }
+}
+
+pub fn query_token_info(deps: Deps) -> StdResult<TokenInfoResponse> {
+    let info = TOKEN_INFO.load(deps.storage)?;
+    let res = TokenInfoResponse {
+        name: info.name,
+        symbol: info.symbol,
+        decimals: info.decimals,
+        total_supply: info.total_supply,
+    };
+    Ok(res)
+}
+
+pub fn query_download_logo(deps: Deps) -> StdResult<DownloadLogoResponse> {
+    let logo = LOGO.load(deps.storage)?;
+    match logo {
+        Logo::Embedded(EmbeddedLogo::Svg(logo)) => Ok(DownloadLogoResponse {
+            mime_type: "image/svg+xml".to_owned(),
+            data: logo,
+        }),
+        Logo::Embedded(EmbeddedLogo::Png(logo)) => Ok(DownloadLogoResponse {
+            mime_type: "image/png".to_owned(),
+            data: logo,
+        }),
+        Logo::Url(_) => Err(StdError::not_found("logo")),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;    
+
+    // We migrate, then mint tokens to the other contract.
+    deps.api.addr_validate(&msg.tf_core_address)?;
+
+    // check if msg.tf_denom starts with factory
+    if !msg.tf_denom.starts_with("factory") {
+        return Err(ContractError::InvalidDenom {});
+    }
+
+    // Save ther data for who mints & the denom to mint from said contract
+    // This contract addr has to be whitelisted to do this.
+    MIGRATION.save(deps.storage, &MigrateConfig {
+        tf_core_address: msg.tf_core_address,     
+        tf_denom: msg.tf_denom,  
+    })?;
+
+        
+    // clear all allowances that will never be used again
+    ALLOWANCES.clear(deps.storage);
+    ALLOWANCES_SPENDER.clear(deps.storage);
+    
+    Ok(Response::default())
+}

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -1,0 +1,28 @@
+use cosmwasm_std::{Deps, Order, StdResult};
+use cw20::{
+    AllAccountsResponse,    
+};
+
+use crate::state::{BALANCES};
+use cw_storage_plus::Bound;
+
+// settings for pagination
+const MAX_LIMIT: u32 = 30;
+const DEFAULT_LIMIT: u32 = 10;
+
+pub fn query_all_accounts(
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<AllAccountsResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
+
+    let accounts = BALANCES
+        .keys(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|item| item.map(Into::into))
+        .collect::<StdResult<_>>()?;
+
+    Ok(AllAccountsResponse { accounts })
+}

--- a/contracts/cw20-base/src/error.rs
+++ b/contracts/cw20-base/src/error.rs
@@ -1,0 +1,50 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{msg}")]
+    Disabled { msg: String },
+
+    #[error("You must use a denom which starts with 'factory/' here")]
+    InvalidDenom {},
+
+    #[error("This contract is migrate only to convert it to a tokenfactory denominartion")]
+    CannotInstantiate {},
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Cannot set to own account")]
+    CannotSetOwnAccount {},
+
+    #[error("Invalid zero amount")]
+    InvalidZeroAmount {},
+
+    #[error("Allowance is expired")]
+    Expired {},
+
+    #[error("No allowance for this account")]
+    NoAllowance {},
+
+    #[error("Minting cannot exceed the cap")]
+    CannotExceedCap {},
+
+    #[error("Logo binary data exceeds 5KB limit")]
+    LogoTooBig {},
+
+    #[error("Invalid xml preamble for SVG")]
+    InvalidXmlPreamble {},
+
+    #[error("Invalid png header")]
+    InvalidPngHeader {},
+
+    #[error("Invalid expiration value")]
+    InvalidExpiration {},
+
+    #[error("Duplicate initial balance addresses")]
+    DuplicateInitialBalanceAddresses {},
+}

--- a/contracts/cw20-base/src/lib.rs
+++ b/contracts/cw20-base/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod contract;
+pub mod enumerable;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -108,4 +108,6 @@ pub enum QueryMsg {
 pub struct MigrateMsg {
     pub tf_core_address: String,
     pub tf_denom: String,
+
+    pub burn_cw20_balances: bool,
 }

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -1,0 +1,111 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{StdError, StdResult, Uint128};
+use cw20::{Cw20Coin, Logo, MinterResponse};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// https://github.com/cosmorama/wynddex/blob/main/contracts/raw-migration/src/contract.rs#L210
+#[cw_serde]
+pub enum ExecuteMsg {
+    /// Iterates through balances, mints the limit to the recipiant
+    MigrateTokens { limit: Option<u32> },
+}
+
+#[cw_serde]
+pub struct InstantiateMarketingInfo {
+    pub project: Option<String>,
+    pub description: Option<String>,
+    pub marketing: Option<String>,
+    pub logo: Option<Logo>,
+}
+
+#[cw_serde]
+#[cfg_attr(test, derive(Default))]
+pub struct InstantiateMsg {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub initial_balances: Vec<Cw20Coin>,
+    pub mint: Option<MinterResponse>,
+    pub marketing: Option<InstantiateMarketingInfo>,
+}
+
+impl InstantiateMsg {
+    pub fn get_cap(&self) -> Option<Uint128> {
+        self.mint.as_ref().and_then(|v| v.cap)
+    }
+
+    pub fn validate(&self) -> StdResult<()> {
+        // Check name, symbol, decimals
+        if !self.has_valid_name() {
+            return Err(StdError::generic_err(
+                "Name is not in the expected format (3-50 UTF-8 bytes)",
+            ));
+        }
+        if !self.has_valid_symbol() {
+            return Err(StdError::generic_err(
+                "Ticker symbol is not in expected format [a-zA-Z\\-]{3,12}",
+            ));
+        }
+        if self.decimals > 18 {
+            return Err(StdError::generic_err("Decimals must not exceed 18"));
+        }
+        Ok(())
+    }
+
+    fn has_valid_name(&self) -> bool {
+        let bytes = self.name.as_bytes();
+        if bytes.len() < 3 || bytes.len() > 50 {
+            return false;
+        }
+        true
+    }
+
+    fn has_valid_symbol(&self) -> bool {
+        let bytes = self.symbol.as_bytes();
+        if bytes.len() < 3 || bytes.len() > 12 {
+            return false;
+        }
+        for byte in bytes.iter() {
+            if (*byte != 45) && (*byte < 65 || *byte > 90) && (*byte < 97 || *byte > 122) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    /// Returns metadata on the contract - name, decimals, supply, etc.
+    #[returns(cw20::TokenInfoResponse)]
+    TokenInfo {},
+    /// Only with "mintable" extension.
+    /// Returns who can mint and the hard cap on maximum tokens after minting.
+    #[returns(cw20::MinterResponse)]
+    Minter {},
+    /// Only with "enumerable" extension
+    /// Returns all accounts that have balances. Supports pagination.
+    #[returns(cw20::AllAccountsResponse)]
+    AllAccounts {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Only with "marketing" extension
+    /// Returns more metadata on the contract to display in the client:
+    /// - description, logo, project url, etc.
+    #[returns(cw20::MarketingInfoResponse)]
+    MarketingInfo {},
+    /// Only with "marketing" extension
+    /// Downloads the embedded logo data (if stored on chain). Errors if no logo data is stored for this
+    /// contract.
+    #[returns(cw20::DownloadLogoResponse)]
+    DownloadLogo {},
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct MigrateMsg {
+    pub tf_core_address: String,
+    pub tf_denom: String,
+}

--- a/contracts/cw20-base/src/state.rs
+++ b/contracts/cw20-base/src/state.rs
@@ -1,0 +1,46 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+
+use cw20::{Logo, MarketingInfoResponse, AllowanceResponse};
+
+#[cw_serde]
+pub struct TokenInfo {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub total_supply: Uint128,
+    pub mint: Option<MinterData>,
+}
+
+#[cw_serde]
+pub struct MinterData {
+    pub minter: Addr,
+    /// cap is how many more tokens can be issued by the minter
+    pub cap: Option<Uint128>,
+}
+
+impl TokenInfo {
+    pub fn get_cap(&self) -> Option<Uint128> {
+        self.mint.as_ref().and_then(|v| v.cap)
+    }
+}
+
+#[cw_serde]
+pub struct MigrateConfig {
+    pub tf_core_address: String,
+    pub tf_denom: String,
+}
+
+/// Stores the contract configuration at the given key
+pub const MIGRATION: Item<MigrateConfig> = Item::new("migration");
+
+pub const TOKEN_INFO: Item<TokenInfo> = Item::new("token_info");
+pub const MARKETING_INFO: Item<MarketingInfoResponse> = Item::new("marketing_info");
+pub const LOGO: Item<Logo> = Item::new("logo");
+
+pub const BALANCES: Map<&Addr, Uint128> = Map::new("balance");
+
+// we clear these on migrate
+pub const ALLOWANCES: Map<(&Addr, &Addr), AllowanceResponse> = Map::new("allowance");
+pub const ALLOWANCES_SPENDER: Map<(&Addr, &Addr), AllowanceResponse> = Map::new("allowance_spender");

--- a/contracts/cw20-base/src/state.rs
+++ b/contracts/cw20-base/src/state.rs
@@ -30,6 +30,9 @@ impl TokenInfo {
 pub struct MigrateConfig {
     pub tf_core_address: String,
     pub tf_denom: String,
+    pub start_after_addr: Option<String>,
+
+    pub burn_cw20_balances: bool,
 }
 
 /// Stores the contract configuration at the given key


### PR DESCRIPTION
WIP

Migrate contract which disables sends, then execute to Mint tokens through TF core for gas limits.

Future:
- a CW20 wrapper contract? Where Tf Factory core is in the CW20 spec? Sacha requested, are there use cases through?